### PR TITLE
Fix whitespace within startup options

### DIFF
--- a/matlab-plugin-agent/src/main/java/com/mathworks/ci/MatlabCommandRunner.java
+++ b/matlab-plugin-agent/src/main/java/com/mathworks/ci/MatlabCommandRunner.java
@@ -64,6 +64,7 @@ public class MatlabCommandRunner {
         if (opts != null) {
             commandArgs.addAll(Arrays.asList(opts.split(" ")));
         }
+        commandArgs.removeIf(s -> s.isEmpty());
 
         return commandArgs;
     }


### PR DESCRIPTION
Quick fix to remove empty options created if a user accidentally adds too much whitespace. This impacted multi-word options like `-logfile`, and are difficult for users to catch because no errors are thrown.