### PR TITLE
Fix issue with sd flag

### DIFF
--- a/matlab-plugin-agent/src/main/java/com/mathworks/ci/RunMatlabTestsService.java
+++ b/matlab-plugin-agent/src/main/java/com/mathworks/ci/RunMatlabTestsService.java
@@ -43,16 +43,14 @@ public class RunMatlabTestsService extends BuildServiceAdapter {
         // Set up runner - can't be done at construction time since we don't have access to the context
         this.runner.createUniqueFolder(getContext());
 
-        // Move genscript to temp directory
-        File genscriptLocation = new File(this.runner.getTempDirectory(), MatlabConstants.MATLAB_SCRIPT_GENERATOR);
-
         // Prepare command
-        String runnerScript = getRunnerScript(MatlabConstants.TEST_RUNNER_SCRIPT, getGenScriptParametersForTests(this.runner.getTempDirectory().getName()));
-        runnerScript = replaceZipPlaceholder(runnerScript, genscriptLocation.getPath());
+        String runnerScript = getRunnerScript(MatlabConstants.TEST_RUNNER_SCRIPT, 
+                getGenScriptParametersForTests(this.runner.getTempDirectory().getName()),
+                this.runner.getTempDirectory().getAbsolutePath());
 
         ProgramCommandLine value;
         try {
-            this.runner.copyFileToWorkspace(MatlabConstants.MATLAB_SCRIPT_GENERATOR, genscriptLocation);
+            this.runner.unzipToTempDir(MatlabConstants.MATLAB_SCRIPT_GENERATOR);
             value = this.runner.createCommand(getContext(), runnerScript);
         } catch (Exception e) {
             throw new RunBuildException(e);
@@ -62,14 +60,9 @@ public class RunMatlabTestsService extends BuildServiceAdapter {
         return value;
     }
 
-    //This method replaces the placeholder with genscript's zip file location URL in temp folder
-    private String replaceZipPlaceholder(String script, String url) {
-        script = script.replace("${ZIP_FILE}", url.replaceAll("'", "''"));
-        return script;
-    }
-
-    //To get therunner script
-    private String getRunnerScript(String script, String params) {
+    //To get the runner script
+    private String getRunnerScript(String script, String params, String tempFolder) {
+        script = script.replace("${TEMPFOLDER}", tempFolder);
         script = script.replace("${PARAMS}", params);
         return script;
     }

--- a/matlab-plugin-agent/src/test/java/com/mathworks/ci/MatlabCommandRunnerTest.java
+++ b/matlab-plugin-agent/src/test/java/com/mathworks/ci/MatlabCommandRunnerTest.java
@@ -149,7 +149,9 @@ public class MatlabCommandRunnerTest {
         String command = "disp(\"Hello world\")";
 
         List<String> expectedCommand = new ArrayList<String>();
-        expectedCommand.add("addpath('" + currDir.getPath().replaceAll("'", ";;") + "');" + "matlab_" + currDir.getName());
+        expectedCommand.add("setenv('MW_ORIG_WORKING_FOLDER', cd('" 
+                + currDir.getPath().replaceAll("'", ";;") 
+                + "'));" + "matlab_" + currDir.getName());
 
         Method generateCommandArgs = getAccessibleMethod("generateCommandArgs", BuildRunnerContext.class, String.class);
 
@@ -160,7 +162,7 @@ public class MatlabCommandRunnerTest {
         Assert.assertTrue(expectedFile.exists());
 
         String contents = FileUtils.readFileToString(expectedFile);
-        Assert.assertEquals(contents, "cd '" + currDir.getPath() + "';\n" + command);
+        Assert.assertEquals(contents, "cd(getenv('MW_ORIG_WORKING_FOLDER'));\n" + command);
     }
 
     // startup options test

--- a/matlab-plugin-agent/src/test/java/com/mathworks/ci/RunMatlabTestsTest.java
+++ b/matlab-plugin-agent/src/test/java/com/mathworks/ci/RunMatlabTestsTest.java
@@ -96,7 +96,7 @@ public class RunMatlabTestsTest {
         Mockito.verify(runner).createCommand(isNull(), matlabCommand.capture());
 
         String expected = MatlabConstants.TEST_RUNNER_SCRIPT.replace("${PARAMS}", genscriptArgs)
-            .replace("${ZIP_FILE}", genscriptZipLocation);
+            .replace("${TEMPFOLDER}", tempDir.getAbsolutePath());
         
         Assert.assertEquals(expected, matlabCommand.getValue());
     }
@@ -125,7 +125,7 @@ public class RunMatlabTestsTest {
                 "'HTMLCodeCoverage','.matlab/tempDir/htmlCoverage'";
 
         String genscriptZipLocation = new File(tempDir, "matlab-script-generator.zip").getAbsolutePath();
-        String expectedGeneratedScript = MatlabConstants.TEST_RUNNER_SCRIPT.replace("${ZIP_FILE}", genscriptZipLocation)
+        String expectedGeneratedScript = MatlabConstants.TEST_RUNNER_SCRIPT.replace("${TEMPFOLDER}", tempDir.getAbsolutePath())
                                         .replace("${PARAMS}", expectedGenscriptArgs);
         return new Object[][] {{envMapsWithAllUserInputs, expectedGeneratedScript}};
     }

--- a/matlab-plugin-common/src/main/java/com/mathworks/ci/MatlabConstants.java
+++ b/matlab-plugin-common/src/main/java/com/mathworks/ci/MatlabConstants.java
@@ -40,16 +40,11 @@ public interface MatlabConstants {
 
   //MATLAB Runner Script
   static final String TEST_RUNNER_SCRIPT = String.join(NEW_LINE,
-      "tmpDir=tempname;",
-      "mkdir(tmpDir);",
-      "addpath(tmpDir);",
-      "zipURL='${ZIP_FILE}';",
-      "unzip(zipURL,tmpDir);",
+      "addpath('${TEMPFOLDER}');",
       "testScript = genscript(${PARAMS});",
       "disp('Running MATLAB script with content:');",
       "disp(testScript.Contents);",
-      "testScript.writeToFile(fullfile(tmpDir,'runnerScript.m'));",
       "fprintf('___________________________________\\n\\n');",
-      "runnerScript()");
+      "run(testScript);");
 }
 


### PR DESCRIPTION
This change resolves an issue with the `-sd` startup option where the actions would not actually run in the directory the user specified.

These changes should also fix two issues, where the temporary directory that was being created for the run-tests task was not being cleaned up, and that the script created by `genscript` was not being cleaned up.