### PR TITLE
Update release process

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,17 +1,19 @@
-name: run-tests
-
+name: Run tests
 on:
   push:
-
 jobs:
   test:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
-
     steps:
-      - uses: actions/checkout@v3
-
+      - uses: actions/checkout@v4
+      - name: Set up JDK 11
+        uses: actions/setup-java@v4
+        with:
+          java-version: '11'
+          distribution: 'temurin'
+          cache: 'maven'
       - name: Run Maven tests
-        run: mvn -B verify --file pom.xml
+        run: mvn verify

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -1,45 +1,27 @@
 # This workflow will build a package using Maven and then publish it to GitHub packages when a release is created
-# For more information see: https://github.com/actions/setup-java/blob/main/docs/advanced-usage.md#apache-maven-with-a-settings-path
-
 name: Maven Package
-
 on:
   release:
     types: published
-
 jobs:
   build:
-
     runs-on: ubuntu-latest
     permissions:
       contents: write
-      packages: write
-
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up JDK 11
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: '11'
           distribution: 'temurin'
-          server-id: github # Value of the distributionManagement/repository/id field of the pom.xml
-          settings-path: ${{ github.workspace }} # location for the settings.xml file
-
+          cache: 'maven'
       - name: Build with Maven
-        run: mvn -B package --file pom.xml
-
+        run: mvn package
       - name: Rename plugin with version number
         run: mv ./target/matlab-plugin.zip ./target/matlab-teamcity-plugin-${{ github.event.release.tag_name }}.zip
-
-      - name: Upload Release Asset New
-        id: upload-release-asset
-        uses: actions/upload-release-asset@v1
+      - name: Upload release asset
+        run: |
+          gh release upload ${{ github.event.release.tag_name }} target/matlab-teamcity-plugin-${{ github.event.release.tag_name }}.zip
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: https://uploads.github.com/repos/mathworks/matlab-teamcity-plugin/releases/${{ github.event.release.id }}/assets{?name,label}
-          asset_path: ./target/matlab-teamcity-plugin-${{ github.event.release.tag_name }}.zip
-          asset_name: matlab-teamcity-plugin-${{ github.event.release.tag_name }}.zip
-          asset_content_type: application/zip
-    env:
-      GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/maven-publish.yml
+++ b/.github/workflows/maven-publish.yml
@@ -1,5 +1,5 @@
 # This workflow will build a package using Maven and then publish it to GitHub packages when a release is created
-name: Maven Package
+name: Publish plugin
 on:
   release:
     types: published

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 servers
+target
+matlab-plugin-agent/src/main/resources/**/run-matlab-command*
+matlab-plugin-agent/src/main/resources/matlab-script-generator.zip
 /.idea/


### PR DESCRIPTION
Changes:
* Use maven caching provided by setup-java action to speed up build times 🔥 
* Update versions of all actions
* Use `gh` cli to upload the release asset
* Removed some configuration if it was unused or agrees with default value
* Updated `.gitignore` so running `git add .` won't add unwanted files to commit