### PR TITLE
Add initial maca support

### DIFF
--- a/matlab-plugin-agent/pom.xml
+++ b/matlab-plugin-agent/pom.xml
@@ -78,7 +78,7 @@
               <goal>wget</goal>
             </goals>
             <configuration>
-              <url>https://ssd.mathworks.com/supportfiles/ci/run-matlab-command/v1/glnxa64/run-matlab-command</url>
+              <url>https://ssd.mathworks.com/supportfiles/ci/run-matlab-command/v2/glnxa64/run-matlab-command</url>
               <unpack>false</unpack>
               <skipCache> true </skipCache>
               <overwrite> true </overwrite>
@@ -86,13 +86,27 @@
             </configuration>
           </execution>
           <execution>
-            <id>get-matlab-runner-mac</id>
+            <id>get-matlab-runner-maca</id>
             <phase>validate</phase>
             <goals>
               <goal>wget</goal>
             </goals>
             <configuration>
-              <url>https://ssd.mathworks.com/supportfiles/ci/run-matlab-command/v1/maci64/run-matlab-command</url>
+              <url>https://ssd.mathworks.com/supportfiles/ci/run-matlab-command/v2/maca64/run-matlab-command</url>
+              <unpack>false</unpack>
+              <skipCache> true </skipCache>
+              <overwrite> true </overwrite>
+              <outputDirectory>${basedir}/src/main/resources/maca64</outputDirectory>
+            </configuration>
+          </execution>
+          <execution>
+            <id>get-matlab-runner-maci</id>
+            <phase>validate</phase>
+            <goals>
+              <goal>wget</goal>
+            </goals>
+            <configuration>
+              <url>https://ssd.mathworks.com/supportfiles/ci/run-matlab-command/v2/maci64/run-matlab-command</url>
               <unpack>false</unpack>
               <skipCache> true </skipCache>
               <overwrite> true </overwrite>
@@ -106,7 +120,7 @@
               <goal>wget</goal>
             </goals>
             <configuration>
-              <url>https://ssd.mathworks.com/supportfiles/ci/run-matlab-command/v1/win64/run-matlab-command.exe</url>
+              <url>https://ssd.mathworks.com/supportfiles/ci/run-matlab-command/v2/win64/run-matlab-command.exe</url>
               <unpack>false</unpack>
               <skipCache> true </skipCache>
               <overwrite> true </overwrite>

--- a/matlab-plugin-agent/src/main/java/com/mathworks/ci/MatlabCommandRunner.java
+++ b/matlab-plugin-agent/src/main/java/com/mathworks/ci/MatlabCommandRunner.java
@@ -95,7 +95,11 @@ public class MatlabCommandRunner {
 
             executable = runnerExe.getPath();
 
-            copyFileToWorkspace(MatlabConstants.RUN_EXE_MAC, new File(runnerExe.getPath()));
+            if (System.getProperty("os.arch").equals("aarch64")) {
+                copyFileToWorkspace(MatlabConstants.RUN_EXE_MACA, new File(runnerExe.getPath()));
+            } else {
+                copyFileToWorkspace(MatlabConstants.RUN_EXE_MACI, new File(runnerExe.getPath()));
+            }
         } else {
             final File runnerExe = new File(this.tempDirectory, "run-matlab-command");
 

--- a/matlab-plugin-common/src/main/java/com/mathworks/ci/MatlabConstants.java
+++ b/matlab-plugin-common/src/main/java/com/mathworks/ci/MatlabConstants.java
@@ -31,7 +31,8 @@ public interface MatlabConstants {
   String TEMP_MATLAB_FOLDER_NAME = ".matlab";
   // Matlab Runner files
   static final String RUN_EXE_WIN = "win64/run-matlab-command.exe";
-  static final String RUN_EXE_MAC = "maci64/run-matlab-command";
+  static final String RUN_EXE_MACA = "maca64/run-matlab-command";
+  static final String RUN_EXE_MACI = "maci64/run-matlab-command";
   static final String RUN_EXE_LINUX = "glnxa64/run-matlab-command";
   static final String MATLAB_SCRIPT_GENERATOR = "matlab-script-generator.zip";
   //Test runner file prefix


### PR DESCRIPTION
To be qualified to make sure that this correctly gets the architecture of the agent rather than the server. PR will be unmarked for draft when verified.